### PR TITLE
Implied_port support & make log statements go on one line

### DIFF
--- a/core/controller.py
+++ b/core/controller.py
@@ -212,21 +212,23 @@ class Controller:
         datagrams_to_send = []
         try:
             msg = self.msg_f.incoming_msg(datagram)
-            
+            logger.debug("Incomming dht message: %s", repr(msg))
         except(message.MsgError):
             # ignore message
+            logger.exception("Error while decoding dht message")
             return self._next_main_loop_call_ts, datagrams_to_send
 
         if msg.type == message.QUERY:
            
             if msg.src_node.id == self._my_id:
-                logger.debug('Got a msg from myself:\n%r', msg)
+                logger.debug('Got a msg from myself: %r', msg)
                 return self._next_main_loop_call_ts, datagrams_to_send
             #zinat: inform experimental_module
             exp_queries_to_send = self._experimental_m.on_query_received(msg)
             
             response_msg = self._responder.get_response(msg)
             if response_msg:
+                logger.debug("Sending out response %s", repr(response_msg))
                 bencoded_response = response_msg.stamp(msg.tid)
                 datagrams_to_send.append(
                     message.Datagram(bencoded_response, addr))
@@ -299,6 +301,7 @@ class Controller:
                         callback_f(lookup_id, None, msg.src_node)
                 if lookup_done:
                     datagrams = self._announce(related_query.lookup_obj)
+                    logger.debug("Sending out message %s", repr(datagrams))
                     datagrams_to_send.extend(datagrams)
             # maintenance related tasks
             maintenance_queries_to_send = \

--- a/core/pymdht.py
+++ b/core/pymdht.py
@@ -55,7 +55,6 @@ class Pymdht:
                  auto_bootstrap=True,
                  bootstrap_mode=False,
                  swift_port=0):
-        logging_conf.setup(conf_path, debug_level)
         self.controller = controller.Controller(VERSION_LABEL,
                                                 my_node, conf_path,
                                                 routing_m_mod,

--- a/core/querier.py
+++ b/core/querier.py
@@ -63,9 +63,9 @@ class Querier(object):
         for i, query in enumerate(queries):
             msg = query
             tid = self._next_tid()
-            logger.debug('registering query %d to node: %r\n%r' % (i,
-                                                                   query.dst_node,
-                                                                   msg))
+            logger.debug('registering query %d to node: %r msg: %r' % (i,
+                                                                    query.dst_node,
+                                                                    msg))
             self._timeouts.append((timeout_ts, msg))
             # if node is not in the dictionary, it will create an empty list
             self._pending.setdefault(query.dst_node.addr, []).append(msg)
@@ -84,14 +84,14 @@ class Querier(object):
         if response_msg.type == message.RESPONSE:
             logger.debug('response received: %s' % repr(response_msg))
         elif response_msg.type == message.ERROR:
-            logger.warning('Error message received:\n%s\nSource: %s',
+            logger.warning('Error message received %s Source: %s',
                            `response_msg`,
                            `response_msg.src_addr`)
         else:
             raise Exception, 'response_msg must be response or error'
         related_query = self._find_related_query(response_msg)
         if not related_query:
-            logger.warning('No query for this response\n%s\nsource: %s' % (
+            logger.warning('No query for this response %s source: %s' % (
                     response_msg, response_msg.src_addr))
         return related_query
 

--- a/core/responder.py
+++ b/core/responder.py
@@ -46,7 +46,7 @@ class Responder(object):
             #first in the bucket.
             peers = self._tracker.get(msg.info_hash)
             if peers:
-                logger.debug('RESPONDING with PEERS:\n%r' % peers)
+                logger.debug('RESPONDING with PEERS: %r' % peers)
             return self.msg_f.outgoing_get_peers_response(
                 msg.src_node, token, nodes=rnodes, peers=peers)
         elif msg.query == message.ANNOUNCE_PEER:

--- a/plugins/routing_nice_rtt.py
+++ b/plugins/routing_nice_rtt.py
@@ -111,8 +111,7 @@ class RoutingManager(object):
             log_distance = lookup_target.distance(self.my_node.id).log
             nodes = self.get_closest_rnodes(log_distance, 0, True)
         return lookup_target, nodes
-        
-                
+
     def do_maintenance(self):
         queries_to_send = []
         maintenance_lookup = None


### PR DESCRIPTION
Companion PR to [Gumby PR #330](https://github.com/Tribler/gumby/pull/330)
Main feature is implementation of the implied_port feature from [BEP5](http://www.bittorrent.org/beps/bep_0005.html).
Some log changes are made to make log lines stay on one line, and output to the tribler logger. This *really* helps when integrating multiple gumby logs.